### PR TITLE
Android SDK upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Integrate the [Helpscout](https://www.helpscout.com/) Beacon into your React Nat
 
 * [**iOS** SDK](https://developer.helpscout.com/beacon-2/ios/)
 
-    Tested version: `1.0.3`
+    Tested version: [1.0.3](https://github.com/helpscout/beacon-ios-sdk/blob/master/CHANGELOG.md#103-release-january-8-2020) (released 2020-01-08)
 
 This library is compatible with and supported for React Native `v0.60+`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Integrate the [Helpscout](https://www.helpscout.com/) Beacon into your React Nat
 
 * [**Android** SDK](https://developer.helpscout.com/beacon-2/android/)
 
-    Current version: `2.0.1`
+    Current version: [2.3.1](https://github.com/helpscout/beacon-android-sdk-sample/blob/master/CHANGELOG.md#version-231-2020-12-21) (released 2020-12-21)
 
 * [**iOS** SDK](https://developer.helpscout.com/beacon-2/ios/)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Integrate the [Helpscout](https://www.helpscout.com/) Beacon into your React Nat
 
 * [**iOS** SDK](https://developer.helpscout.com/beacon-2/ios/)
 
-    Tested version: [1.0.3](https://github.com/helpscout/beacon-ios-sdk/blob/master/CHANGELOG.md#103-release-january-8-2020) (released 2020-01-08)
+    Tested version: [2.0.2](https://github.com/helpscout/beacon-ios-sdk/blob/master/CHANGELOG.md#202-september-16-2020) (released 2020-09-16)
 
 This library is compatible with and supported for React Native `v0.60+`.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@
 
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_MIN_SDK_VERSION = 21
 def DEFAULT_TARGET_SDK_VERSION = 28
 
 def safeExtGet(prop, fallback) {
@@ -53,6 +53,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {
@@ -73,8 +77,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation "com.helpscout:beacon-core:2.0.1"
-    implementation "com.helpscout:beacon-ui:2.0.1"
+    implementation "com.helpscout:beacon-ui:2.3.1"
 }
 
 def configureReactNativePom(def pom) {

--- a/index.js
+++ b/index.js
@@ -62,14 +62,27 @@ const loginAndOpen = (email, name, userId, signature = null) => {
   }
 };
 
+/**
+ * Display the Beacon user interface.
+ *
+ * @param {String} signature
+ */
+const open = (signature = null) => {
+  if (signature === null) {
+    HelpscoutBeacon.open(null);
+  } else {
+    HelpscoutBeacon.open(signature);
+  }
+}
+
 const HSBeacon = {
   init: HelpscoutBeacon.init,
   identify,
   login,
   loginAndOpen,
+  open,
   logout: HelpscoutBeacon.logout,
   addAttributeWithKey: HelpscoutBeacon.addAttributeWithKey,
-  open: HelpscoutBeacon.open,
   openArticle: HelpscoutBeacon.openArticle,
   suggestArticles: HelpscoutBeacon.suggestArticles,
   resetSuggestions: HelpscoutBeacon.resetSuggestions


### PR DESCRIPTION
Closes #4 

This PR ... 

1. Updates the HelperScout Beacon Android SDK to its newest version
2. Wraps the native `HelpscoutBeacon.open` function so that its JavaScript abstraction may be called without setting the `signature` parameter