### PR TITLE
WIP: Feat/5 ios sdk upgrade

### DIFF
--- a/ios/HelpscoutBeacon.m
+++ b/ios/HelpscoutBeacon.m
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(identify:(NSString *)email nameParameter:(NSString *)name)
 
     // Store beaconUser locally
     beaconUser = user;
-    [HSBeacon login:user];
+    [HSBeacon identify:user];
 }
 
 RCT_EXPORT_METHOD(addAttributeWithKey:(NSString *)key valueParameter:(NSString *)value)

--- a/react-native-helpscout-beacon.podspec
+++ b/react-native-helpscout-beacon.podspec
@@ -7,14 +7,14 @@ Pod::Spec.new do |s|
   s.version      = package["version"]
   s.summary      = package["description"]
   s.description  = <<-DESC
-                  react-native-helpscout-beacon
+                  React Native module for the Help Scout Beacon SDK
                    DESC
   s.homepage     = "https://github.com/Driversnote-Dev/react-native-helpscout-beacon"
   s.license      = "MIT"
   # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
   s.authors      = { "Driversnote.com" => "ja@driversnote.com" }
   s.platforms    = { :ios => "9.0" }
-  s.source       = { :git => "https://github.com/Driversnote-Dev/react-native-helpscout-beacon.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/Driversnote-Dev/react-native-helpscout-beacon.git", :tag => package["version"] }
 
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true


### PR DESCRIPTION
Closes #5 

Fixes two issues which have to be done to upgrade the HelpScout Beacon iOS SDK beyond version `2.1.0`

This is still work in progress because of the issues described in #5 