### PR TITLE
Add `navigate` API method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,21 @@ HelpscoutBeacon.suggestArticles(articleIDList);
 Reset any suggested articles set by `suggestArticles` back to Helpscouts own default suggestions.
 
 ```javascript
-HelpscoutBeacon.openArticle('some_article_id', 'my_signature');
+HelpscoutBeacon.resetSuggestions();
+```
+
+#### `navigate`
+
+Display a specific page in the Helpscout beacon. On Android, these paths are supported:
+
+- "/ask/message/"
+- "/ask/chat/"
+- "/answers/"
+
+iOS supports additional paths e.g. "/" which displays the initial state of the beacon. Find supported path values [here](https://developer.helpscout.com/beacon-2/ios/#navigate-to-a-specific-screen).
+
+```javascript
+HelpscoutBeacon.navigate('/ask/message');
 ```
 
 ### Additional convenience methods

--- a/android/src/main/java/com/driversnote/HelpscoutBeaconModule.java
+++ b/android/src/main/java/com/driversnote/HelpscoutBeaconModule.java
@@ -149,6 +149,28 @@ public class HelpscoutBeaconModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void navigate(String path) {
+        if (beacon == null) {
+            Log.w(TAG, "[navigate] Not initialized - did you forget to call 'init'?");
+            return;
+        }
+        switch (path) {
+            case "/ask/message/":
+                BeaconActivity.open(this.reactContext, BeaconScreens.CONTACT_FORM_SCREEN, new ArrayList<String>());
+                break;
+            case "/ask/chat/":
+                BeaconActivity.open(this.reactContext, BeaconScreens.CHAT, new ArrayList<String>());
+                break;
+            case "/answers/":
+                BeaconActivity.open(this.reactContext, BeaconScreens.PREVIOUS_MESSAGES, new ArrayList<String>());
+                break;
+            default:
+                Log.w(TAG, "[navigate] Path '" + (path != null ? path : "null") + "' not supported");
+                break;
+        }
+    }
+
+    @ReactMethod
     public void suggestArticles(ReadableArray articleIds) {
         if (beacon == null || articleIds == null) {
             if (beacon == null) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const identify = (email, name = null) => {
 const login = (email, name, userId) => {
   if (!email || !name || !userId) {
     console.error(
-      `[login] Missing parameter. Either 'email', 'name', 'userId' or several of them are missing.`
+      "[login] Missing parameter. Either 'email', 'name', 'userId' or several of them are missing."
     );
     return;
   }
@@ -75,12 +75,36 @@ const open = (signature = null) => {
   }
 }
 
+/**
+ * Display a specific page in the Helpscout beacon. On Android, these paths
+ * are supported:
+ * - "/ask/message/"
+ * - "/ask/chat/"
+ * - "/answers/"
+ * 
+ * iOS supports additional paths e.g. "/" which displays the initial state
+ * of the beacon. Find supported path values here:
+ * - https://developer.helpscout.com/beacon-2/ios/#navigate-to-a-specific-screen
+ * 
+ * @param {String} path
+ */
+const navigate = (path) => {
+  if (!path) {
+    console.error(
+      "[navigate] Missing parameter: path"
+    );
+    return;
+  }
+  HelpscoutBeacon.navigate(path);
+}
+
 const HSBeacon = {
   init: HelpscoutBeacon.init,
   identify,
   login,
   loginAndOpen,
   open,
+  navigate,
   logout: HelpscoutBeacon.logout,
   addAttributeWithKey: HelpscoutBeacon.addAttributeWithKey,
   openArticle: HelpscoutBeacon.openArticle,

--- a/ios/HelpscoutBeacon.m
+++ b/ios/HelpscoutBeacon.m
@@ -93,6 +93,22 @@ RCT_EXPORT_METHOD(open:(NSString *)signatureKey)
     }
 }
 
+RCT_EXPORT_METHOD(navigate:(NSString *)path)
+{
+    if (helpscoutBeaconID == nil || path == nil) {
+        if (helpscoutBeaconID == nil) {
+            NSLog(@"[navigate] Not initialized - did you forget to call 'init'?");
+        }
+        if (path == nil) {
+            NSLog(@"[navigate] missing parameter: path");
+        }
+        return;
+    }
+
+    HSBeaconSettings *settings = [[HSBeaconSettings alloc] initWithBeaconId:helpscoutBeaconID];
+    [HSBeacon navigate:path beaconSettings:settings];
+}
+
 RCT_EXPORT_METHOD(logout)
 {
     if (helpscoutBeaconID == nil) {


### PR DESCRIPTION
Add API method for calling `navigate` on the native SDKs.

Unfortunately, the `navigate` function is somewhat different between iOS and Android, so while an arbitrary non-null/non-empty string will be accepted on iOS, the supported `path` argument on Android is restricted to one of the following:
- "/ask/message/"
- "/ask/chat/"
- "/answers/"