### PR TITLE
update to latest android beacon sdk 5.2.0 and depend on koin 3.4.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,10 +10,10 @@
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 21
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_COMPILE_SDK_VERSION = 34
+def DEFAULT_BUILD_TOOLS_VERSION = '34.0.0'
+def DEFAULT_MIN_SDK_VERSION = 23
+def DEFAULT_TARGET_SDK_VERSION = 34
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,8 +50,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 }
 
@@ -73,7 +73,19 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation "com.helpscout:beacon:5.1.2"
+    implementation "com.helpscout:beacon:5.2.0"
+
+    api(group: "io.insert-koin", name: "koin-core") {
+        version {
+            strictly "3.4.2"
+        }
+    }
+
+    api(group: "io.insert-koin", name: "koin-android") {
+        version {
+            strictly "3.4.2"
+        }
+    }
 }
 
 def configureReactNativePom(def pom) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,19 +73,8 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation "com.helpscout:beacon:5.2.0"
 
-    api(group: "io.insert-koin", name: "koin-core") {
-        version {
-            strictly "3.4.2"
-        }
-    }
-
-    api(group: "io.insert-koin", name: "koin-android") {
-        version {
-            strictly "3.4.2"
-        }
-    }
+    implementation "com.helpscout:beacon:5.0.2"
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
This is a possible fix to the crash:
https://github.com/Driversnote-Dev/react-native-helpscout-beacon/issues/21

Requirements for helpscout library : https://github.com/helpscout/beacon-android-sdk-sample

```
minSdkVersion: 21
compileSdkVersion:35
Java 11 language feature support (compile with Java 17 as of version 5.0.0)
[Android X](https://developer.android.com/jetpack/androidx/) as of version SDK 2.0.0
A Beacon Id created on [Help Scout](https://secure.helpscout.net/settings/beacons/)
Supported platform and language versions

Android 11.0 to 15.0 (as noted above the "minSdkVersion: 21 (Android 5.0)" for greater compatibility however we only offer support for issues on Android 11+)
Kotlin 1.8.20
Java 11
Koin 3.4.2
```